### PR TITLE
Add Timing for Mac (automatic time tracker)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Todo.txt](http://todotxt.com/) – Tired of having complicated apps to organize your tasks? Todo.txt is a technique that uses a single `.txt` file to help you get the job done.
 - [OmniFocus](https://www.omnigroup.com/omnifocus) – A Getting Things Done based task manager for Mac OS X and iOS.
 - [Taskwarrior](http://taskwarrior.org/) – An open source command line task manager. Flexible, fast, efficient, and unobtrusive.
+- [Timing](https://timingapp.com/) – Automatic time and productivity tracking for Mac. Helps you stay on track with your work and ensures no billable hours get lost if you are billing hourly.
 
 ### Task Automation
  - [IFTTT](https://ifttt.com) – Allows you to create chains of conditional statements (called _recipes_) between web services in order to make the web work for you and boost your productivity.


### PR DESCRIPTION
This commit adds another time tracking app to the list. For testimonials of its awesomeness, see [our Product Hunt page](https://www.producthunt.com/posts/timing-2-3) and [the old version's Mac App Store page](https://itunes.apple.com/us/app/id431511738?mt=12&ign-mpt=uo%3D4). Also happy to send you a free copy so you can see for yourself :-)