### PR TITLE
Add Bitwarden Password Manager to Password Managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 ### Password Manager
 
 - [LastPass](https://lastpass.com) – A freemium password manager that stores encrypted passwords online.
+- [Bitwarden](https://bitwarden.com) - A free, trusted password manager that can store, sync, and generate passwords online or through native apps.
 
 ### Knowledge Management
 

--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 ### Password Manager
 
+— [Bitwarden](https://bitwarden.com) - A free, trusted password manager that can store, sync, and generate passwords online or through native apps.
 - [LastPass](https://lastpass.com) – A freemium password manager that stores encrypted passwords online.
-- [Bitwarden](https://bitwarden.com) - A free, trusted password manager that can store, sync, and generate passwords online or through native apps.
 
 ### Knowledge Management
 


### PR DESCRIPTION
[Bitwarden](https://bitwarden.com/) is an open-source password manager. I believe it should be included as it on par with the quality of LastPass while retaining a "free forever" subscription option.