### PR TITLE
Fix broken outdated link

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 - [Deep Work: Rules for Focused Success in a Distracted World](https://www.calnewport.com/books/deep-work/) - Deep work is the ability to focus without distraction on a cognitively demanding task.
 - [Getting Things Done](https://gettingthingsdone.com/store/product.php?productid=17035&cat=3&page) - A very simple and efficient time-management method.
-- [The 5 Choices](http://books.simonandschuster.ca/The-5-Choices/Kory-Kogon/9781476711713) - An all around productivity methodology dealing with prioritization, scheduling, technology and energy management.
+- [The 5 Choices](https://www.simonandschuster.com/books/The-5-Choices/Kory-Kogon/9781476711829) - An all around productivity methodology dealing with prioritization, scheduling, technology and energy management.
 
 ## Tools and Apps
 
@@ -92,7 +92,7 @@
 - [Emoji Log](https://emojilog.rosano.ca) -  Calm, emoji-based tracker for arbitrary things that doesn't use streaks.
 - [Everyday](https://everyday.app/) - Form new habits by doing things every day.
 - [Habitica](https://habitica.com) - Complete your real life daily goals in a role play game (previously called _HabitRPG_).
-- [HabitBull](http://www.habitbull.com/) - Premium habit tracker.
+- [HabitBull](https://www.habitbull.com/) - Premium habit tracker.
 - [Loop Habit Tracker](https://github.com/iSoron/uhabits) - An Android app for creating and maintaining good habits.
 - [Waka Time](https://wakatime.com/) -  Open source plugin for knowing exactly how long you spend coding.
 
@@ -116,10 +116,9 @@
 
 ### Knowledge Management
 
-- [Obie.ai](https://obie.ai/) - AI platform that brings all knowledge and documentation into one spot.
 - [Obsidian.md](https://obsidian.md/) - A knowledge base tool that works on local Markdown files. It allows you to create links between different notes.
 - [Scribe](https://scribehow.com/) - Automatically create step-by-step guides for any process. Simply hit “record” and Scribe will generate a detailed guide complete with screenshots based on your actions, ready to share with colleagues, customers, and friends.
-- [Logseq](https://logseq.com/) - Logseq is a privacy-first, open-source knowledge base that works on top of local plain-text Markdown and Org-mode files. Use it to write, organize and share your thoughts, keep your to-do list, and build your own digital garden. 
+- [Logseq](https://logseq.com/) - Logseq is a privacy-first, open-source knowledge base that works on top of local plain-text Markdown and Org-mode files. Use it to write, organize and share your thoughts, keep your to-do list, and build your own digital garden.
 
 ### Screen Capture
 

--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@
 
 ## Websites
 
-- [12+ Tips and Tricks to Work Faster in Microsoft Outlook](http://lifehacker.com/12-tips-and-tricks-to-work-faster-in-microsoft-outlook-1540483009) - Tame your Outlook with these tips in order to get a little bit closer to the awesome _Inbox Zero_.
-- [Advanced GTD with Remember The Milk](http://blog.rememberthemilk.com/post/116665489183/guest-post-advanced-gtd-with-remember-the-milk) - A tutorial on how to implement GTD with Remember the Milk.
-- [Inbox Zero](http://www.43folders.com/izero) - Rigorous approach to email management aimed at keeping the inbox (almost) empty at all times.
-- [Lifehacker](http://lifehacker.com/) - The go-to blog for tips, tricks, and downloads for getting things done.
+- [12+ Tips and Tricks to Work Faster in Microsoft Outlook](https://lifehacker.com/12-tips-and-tricks-to-work-faster-in-microsoft-outlook-1540483009) - Tame your Outlook with these tips in order to get a little bit closer to the awesome _Inbox Zero_.
+- [Advanced GTD with Remember The Milk](https://blog.rememberthemilk.com/post/116665489183/guest-post-advanced-gtd-with-remember-the-milk) - A tutorial on how to implement GTD with Remember the Milk.
+- [Inbox Zero](https://www.43folders.com/izero) - Rigorous approach to email management aimed at keeping the inbox (almost) empty at all times.
+- [Lifehacker](https://lifehacker.com/) - The go-to blog for tips, tricks, and downloads for getting things done.
 - [Pomodoro Technique](http://pomodorotechnique.com/) - Slice your tasks in 25 minute packages and get more done in less time.
 - [r/Productivity](https://www.reddit.com/r/productivity/) - Productivity subreddit.
-- [Rid Your Desktop of Clutter with This Simple Trio of Icons](http://lifehacker.com/5901487/rid-your-desktop-of-clutter-with-this-simple-trio-of-icons) - A little trick that has been keeping my desktop clean for years now.
+- [Rid Your Desktop of Clutter with This Simple Trio of Icons](https://lifehacker.com/5901487/rid-your-desktop-of-clutter-with-this-simple-trio-of-icons) - A little trick that has been keeping my desktop clean for years now.
 - [ShortLib](https://shortlib.netlify.app/) - Collection of hundreds of shortcuts for Windows, Mac and Linux.
-- [The Bullet Journal](http://bulletjournal.com/) - A pen and paper method that turns a simple notebook into a highly efficient productivity tool.
+- [The Bullet Journal](https://bulletjournal.com/) - A pen and paper method that turns a simple notebook into a highly efficient productivity tool.
 - [Zen Habits](https://zenhabits.net/) - Blog by Leo Babauta with topics such as simplifying life.
 
 ## Books
@@ -49,7 +49,7 @@
 ### Note Management
 
 - [Evernote](https://evernote.com/) - Evernote can basically become your second brain and remember everything for you.
-- [Google Keep](http://www.google.com/keep/) - A nice and simple note management system tightly integrated with Google products.
+- [Google Keep](https://www.google.com/keep/) - A nice and simple note management system tightly integrated with Google products.
 - [Inkdrop](https://www.inkdrop.info/) - A cross-platform note taking application for Markdown lovers.
 - [Joplin](https://joplinapp.org/) - A note taking and to-do application with synchronization capabilities.
 - [Notion](https://www.notion.so/) - An all-in-one very customizable workspace for notes, tasks, wikis and lists.
@@ -64,7 +64,7 @@
 
 - [Airtable](https://airtable.com/) - Mix of spreadsheet and database to help organize work.
 - [Amazing Marvin](https://www.amazingmarvin.com/) - Marvin incorporates principles from behavioral psychology to help beat procrastination, feel in control and finish todo list.
-- [Any.do](http://www.any.do/) - Simple interface, packed with features, currently the favorite to-do list manager at [Lifehacker](http://lifehacker.com/5924093/five-best-to-do-list-managers).
+- [Any.do](https://www.any.do/) - Simple interface, packed with features, currently the favorite to-do list manager at [Lifehacker](https://lifehacker.com/5924093/five-best-to-do-list-managers).
 - [GitHub Projects](https://github.com/features/project-management/) - A lesser known feature of GitHub, makes it easy to tie your project management process to your code.
 - [Hitask](https://hitask.com) - Easy Project and Task Management for Teams.
 - [KanbanFlow](https://kanbanflow.com) - Kanban method task board with Pomodoro technique.
@@ -74,7 +74,7 @@
 - [Pomolectron](https://github.com/amitmerchant1990/pomolectron) - A pomodoro app for your menubar/tray.
 - [Remember the Milk](https://www.rememberthemilk.com) - Great at managing tags for to-dos and location based tasks.
 - [Taskade](https://taskade.com) - Simple and collaborative task lists for teams.
-- [Taskwarrior](http://taskwarrior.org/) - An open source command line task manager. Flexible, fast, efficient, and unobtrusive.
+- [Taskwarrior](https://taskwarrior.org/) - An open source command line task manager. Flexible, fast, efficient, and unobtrusive.
 - [Timely](https://memory.ai/timely) - Automatic time tracking software. Get a flawless digital record of all project and team time, all without the hassle of manual timers and note taking.
 - [Timing](https://timingapp.com/) - Automatic time and productivity tracking for Mac. Helps you stay on track with your work and ensures no billable hours get lost if you are billing hourly.
 - [Tinido](https://tinido.com/) - A beautiful and simple task management app that can also give you insights by showing your completed tasks in a contribution graph similar to the one you find on your GitHub profile.
@@ -104,7 +104,7 @@
 - [n8n](https://n8n.io) - Open-source workflow automation for connecting web services with an option to self-host.
 - [Qbserve](https://qotoqot.com/qbserve/) - Mac time tracking automation: freelance project tracking, timesheets, invoicing & real-time productivity feedback.
 - [Parabola](https://parabola.io) - Drag and drop tool to build custom reports, workflows, and integrations to automate your manual processes.
-- [Tasker](http://tasker.dinglisch.net/) - Android application that can perform context sensitive custom tasks (_e.g._ automatically turn on wifi when you arrive home).
+- [Tasker](https://tasker.dinglisch.net/) - Android application that can perform context sensitive custom tasks (_e.g._ automatically turn on wifi when you arrive home).
 - [Zapier](https://zapier.com/) - Automation tool that allows you to connect hundreds of web services and create automations between the processes.
 
 ### Password Manager


### PR DESCRIPTION
Some links are outdated. This PR fix them.

- The 5 Choices
    - Link is unreachable. Use another link to same website instead.
- Obei.ai
    - Link is unreachable, and the service seems to be closed.

And, there're HTTP links which leads to HTTPS available websites. So, changing them to `https://`.