### PR TITLE
Add TabbySpaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@
 - [n8n](https://n8n.io) - Open-source workflow automation for connecting web services with an option to self-host.
 - [Qbserve](https://qotoqot.com/qbserve/) - Mac time tracking automation: freelance project tracking, timesheets, invoicing & real-time productivity feedback.
 - [Parabola](https://parabola.io) - Drag and drop tool to build custom reports, workflows, and integrations to automate your manual processes.
+- [TabbySpaces](https://github.com/halilc4/tabbyspaces) - Visual split-layout workspace editor for Tabby terminal with persistent workspaces and startup commands.
 - [Tasker](https://tasker.dinglisch.net/) - Android application that can perform context sensitive custom tasks (_e.g._ automatically turn on wifi when you arrive home).
 - [Zapier](https://zapier.com/) - Automation tool that allows you to connect hundreds of web services and create automations between the processes.
 


### PR DESCRIPTION
[TabbySpaces](https://github.com/halilc4/tabbyspaces) - Visual split-layout workspace editor for Tabby terminal.

A productivity plugin that lets users visually create, edit, and save terminal layouts. Save time by restoring complex multi-pane terminal setups with a single click, including custom working directories and startup commands.

**Key features:**
- Visual drag-and-drop workspace editor
- Persistent workspace configurations
- Auto-generated Tabby profiles
- Per-pane startup commands and working directories