### PR TITLE
Add OpenHabitTracker to Habit Trackers

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@
 - [Habitica](https://habitica.com) - Complete your real life daily goals in a role play game (previously called _HabitRPG_).
 - [HabitBull](https://www.habitbull.com/) - Premium habit tracker.
 - [Loop Habit Tracker](https://github.com/iSoron/uhabits) - An Android app for creating and maintaining good habits.
+- [OpenHabitTracker](https://openhabittracker.net) - Free, open source habit tracker for Web, Windows, Linux, Android, iOS and macOS. Tracks habits without streak counters.
 - [Waka Time](https://wakatime.com/) -  Open source plugin for knowing exactly how long you spend coding.
 - [Conjure](https://conjure.so) - Habits, goals and time tracking platform with rules engine, data layer, API, dashboards and more (Web, Desktop, iOS, Android).
 


### PR DESCRIPTION
OpenHabitTracker is a free, open source habit tracker for Web, Windows, Linux, Android, iOS and macOS. Tracks habits without streak counters. https://openhabittracker.net