### PR TITLE
Add MacMD Viewer to Note Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@
 - [Simplenote](https://simplenote.com/) - Light, clean, and free. Simplenote is now available for iOS, Android, Mac, Windows, Linux, and the web.
 - [Standard Notes](https://standardnotes.org/) - A simple and private notes application.
 - [WorkFlowy](https://workflowy.com/) - Outlining application for nested bulleted lists.
+- [MacMD Viewer](https://macmdviewer.com/) - A native macOS markdown viewer with live reload, sidebar table of contents, syntax highlighting, and Mermaid diagram support.
 
 ### Task Management
 
@@ -120,7 +121,7 @@
 ### Knowledge Management
 
 - [Obsidian.md](https://obsidian.md/) - A knowledge base tool that works on local Markdown files. It allows you to create links between different notes.
-- [Scribe](https://scribehow.com/) - Automatically create step-by-step guides for any process. Simply hit “record” and Scribe will generate a detailed guide complete with screenshots based on your actions, ready to share with colleagues, customers, and friends.
+- [Scribe](https://scribehow.com/) - Automatically create step-by-step guides for any process. Simply hit "record" and Scribe will generate a detailed guide complete with screenshots based on your actions, ready to share with colleagues, customers, and friends.
 - [Logseq](https://logseq.com/) - Logseq is a privacy-first, open-source knowledge base that works on top of local plain-text Markdown and Org-mode files. Use it to write, organize and share your thoughts, keep your to-do list, and build your own digital garden.
 
 ### Screen Capture


### PR DESCRIPTION
Adds [MacMD Viewer](https://macmdviewer.com) — a native macOS markdown viewer for developer productivity.

- Live file watching: auto-reloads when files change on disk
- Sidebar table of contents for quick navigation
- Syntax highlighting for 190+ languages
- Mermaid diagram rendering
- QuickLook extension for previewing `.md` files directly in Finder

Built with Swift/SwiftUI, lightweight ~2MB native app.