### PR TITLE
Adds TimezonePair 

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@
 - [VivifyScrum](https://www.vivifyscrum.com) - Agile project management app for teams that deliver. Customizable Scrum and Kanban boards.
 - [Bordio](https://bordio.com/) - Daily planner for managing tasks and events on one board.
 - [OpenProject](https://www.openproject.org/) - An on premise open source project management solution that comes with a free community version as well as an enterprise version.
+- [TimezonePair](https://www.timezonepair.com) - Live clocks and business-hours overlap for any two cities. One-click .ics calendar invite, shareable URL, DST-aware, no sign-up.
 
 ### Habit Trackers
 


### PR DESCRIPTION
Add TimezonePair to Task Management

Add TimezonePair (https://www.timezonepair.com/) — a free tool for distributed teams to find live business-hours overlap across any two cities, with one-click .ics calendar invites and shareable URLs. DST-aware, no sign-up.