### PR TITLE
Add ArcOffice - Local-first AI-powered office desktop client

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
   - [Password Manager](#password-manager)
   - [Knowledge Management](#knowledge-management)
   - [Screen Capture](#screen-capture)
+  - [Office Suite](#office-suite)
 
 ## Websites
 
@@ -128,3 +129,7 @@
 - [ShareX](https://getsharex.com/) - Screen capture, file sharing and productivity tool.
 - [Replayable](https://replayable.io) - Rewind your screen. Playback and share exactly what happened with Replayable's desktop replay buffer.
 - [CleanShot](https://cleanshot.com/) - A premium tool for screen capturing and recording on MacOS, with built-in annotation and text recognition.
+
+### Office Suite
+
+- [ArcOffice](https://github.com/Arc-River/ArcOffice) - Local-first AI-powered office desktop client with document editing, batch processing, and intelligent file management.


### PR DESCRIPTION
在 Tools and Apps 分类下新增 Office Suite 子分类，并添加 ArcOffice。

- [x] 在 Tools and Apps 分类末尾添加
- [x] 描述简洁有信息量
- [x] 已检查无重复
- [x] 新增子分类在 TOC 中有对应链接

ArcOffice 是一款开源的本地优先 AI 办公桌面客户端，基于 OnlyOffice 和 Claude AI，支持文档编辑、AI 对话、批量任务处理等功能。